### PR TITLE
ツリーレイアウトの実装

### DIFF
--- a/src/main/scala/graphene/core/gui/MainFrame.scala
+++ b/src/main/scala/graphene/core/gui/MainFrame.scala
@@ -4,7 +4,7 @@ import java.awt.{Dimension}
 import java.awt.event.{ActionEvent, ActionListener}
 import java.awt.event.{InputEvent, KeyEvent}
 
-import javax.swing.{JFileChooser, JMenu, JMenuItem, KeyStroke}
+import javax.swing.{JFileChooser, JMenu, JMenuItem, KeyStroke, JScrollPane, ScrollPaneConstants}
 import javax.swing.filechooser.FileNameExtensionFilter
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
@@ -148,7 +148,9 @@ class MainPanel extends javax.swing.JPanel with JPanelExt {
 
       val tabbedPane = new javax.swing.JTabbedPane
       tabbedPane.addTab("General", new SettingPanel)
-      tabbedPane.addTab(plugin.name, controlPanel)
+      val controlPanelScroll = new JScrollPane(controlPanel)
+      controlPanelScroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER)
+      tabbedPane.addTab(plugin.name, controlPanelScroll)
       tabbedPane.addTab("Log", LogPanel)
       tabbedPane
     }

--- a/src/main/scala/graphene/model/Graph.scala
+++ b/src/main/scala/graphene/model/Graph.scala
@@ -91,6 +91,7 @@ class Graph {
 
   private val viewFromID = Map.empty[ID, View]
   private val nodeFromID = Map.empty[ID, Node]
+  private val portOrders = Map.empty[Node, Map[Int, Node]]
 
   var rootNode: Node = _
   var viewBuilder = (n: Node) => new View(Rect(Point.zero, Dim(20, 20)), Color.BLACK)
@@ -111,9 +112,23 @@ class Graph {
     e.target.removeEdge(e)
   }
 
+  def recordPortOrder(node: Node, pos: Int, neighbor: Node): Unit = {
+    val orders = portOrders.getOrElseUpdate(node, Map.empty)
+    orders += pos -> neighbor
+  }
+
+  def orderedNeighbors(node: Node): Seq[Node] =
+    portOrders.get(node).map(_.toSeq.sortBy(_._1).map(_._2)).getOrElse(Seq.empty)
+
   private[model] def register(node: Node) = nodeFromID += node.id -> node
 
-  private[model] def unregister(node: Node) = nodeFromID -= node.id
+  private[model] def unregister(node: Node) = {
+    nodeFromID -= node.id
+    portOrders -= node
+    for ((_, orders) <- portOrders) {
+      orders.retain { case (_, n) => n != node }
+    }
+  }
 
   def viewOf(node: Node): View = viewFromID.getOrElseUpdate(node.id, viewBuilder(node))
 
@@ -146,6 +161,13 @@ class Graph {
     copyRootNode(g, this)
 
     for (e <- allEdges) g.createEdge(e.source.id, e.target.id)
+
+    for ((srcNode, posMap) <- portOrders if nodeFromID.contains(srcNode.id)) {
+      val dstNode = g.nodeOf(srcNode.id)
+      for ((pos, neighbor) <- posMap if nodeFromID.contains(neighbor.id)) {
+        g.recordPortOrder(dstNode, pos, g.nodeOf(neighbor.id))
+      }
+    }
 
     g
   }

--- a/src/main/scala/graphene/plugin/lmntal/AtomStyle.scala
+++ b/src/main/scala/graphene/plugin/lmntal/AtomStyle.scala
@@ -1,0 +1,72 @@
+package graphene.plugin.lmntal
+
+import java.awt.Color
+
+import graphene.model.{Graph, Node}
+import graphene.util.{Dim, Point, Rect}
+
+import scala.collection.mutable
+
+sealed trait AtomShape {
+  def label: String
+}
+
+object AtomShape {
+  case object Circle extends AtomShape {
+    val label = "Circle"
+  }
+  case object RoundedRect extends AtomShape {
+    val label = "RoundedRect"
+  }
+
+  val values: Seq[AtomShape] = Seq(Circle, RoundedRect)
+
+  def fromLabel(label: String): AtomShape = values.find(_.label == label).getOrElse(Circle)
+}
+
+case class AtomStyle(
+  fillColor: Color,
+  strokeColor: Color,
+  textColor: Color,
+  shape: AtomShape,
+  size: Int,
+  cornerRadius: Int
+)
+
+object AtomStyleRegistry {
+  private val styles = mutable.LinkedHashMap.empty[String, AtomStyle]
+  val DefaultAtomSize = 24
+
+  def all: Seq[(String, AtomStyle)] = styles.toSeq
+
+  def get(name: String): Option[AtomStyle] = styles.get(normalize(name))
+
+  def upsert(name: String, style: AtomStyle): Unit = {
+    val key = normalize(name)
+    if (key.nonEmpty) styles.update(key, style)
+  }
+
+  def remove(name: String): Unit = styles.remove(normalize(name))
+
+  def clear(): Unit = styles.clear()
+
+  def styleFor(node: Node): Option[AtomStyle] =
+    if (node.attr == Atom) get(node.name) else None
+
+  def applyToGraph(graph: Graph): Unit = {
+    if (graph != null) graph.allNodes.foreach(applyToNode)
+  }
+
+  def applyToNode(node: Node): Unit = {
+    if (node.attr == Atom) {
+      val styleOpt = styleFor(node)
+      val sizeValue = styleOpt.map(_.size).getOrElse(DefaultAtomSize)
+      val rect = node.view.rect
+      val center = rect.center
+      val size = math.max(4, sizeValue).toDouble
+      node.view.rect = Rect(Point(center.x - size / 2.0, center.y - size / 2.0), Dim(size, size))
+    }
+  }
+
+  private def normalize(name: String): String = name.trim
+}

--- a/src/main/scala/graphene/plugin/lmntal/ControlPanel.scala
+++ b/src/main/scala/graphene/plugin/lmntal/ControlPanel.scala
@@ -1,7 +1,7 @@
 package graphene.plugin.lmntal
 
 import graphene.model.Hot
-import javax.swing.{JPanel,JTextField,JCheckBox,JButton}
+import javax.swing.{JPanel,JTextField,JCheckBox,JButton,JToggleButton,JLabel,JList,JScrollPane,JComboBox,JColorChooser,JSlider,DefaultListModel,ListSelectionModel}
 import graphene.swing.scalalike._
 
 //画面右側のメニュー画面の中身
@@ -127,6 +127,42 @@ class ControlPanel(config: Config) extends JPanel with JPanelExt {
 
     this << new JPanel with JPanelExt {
       layout_ = new BoxLayout(this, BoxLayout.Y_AXIS)
+      border_ = new TitledBorder("Tree Layout")
+
+      this << new ParamPanel("Vertical Gap", BoxLayout.X_AXIS) {
+        val param = config.tree
+        val paramControls = new LogParamControls(10, 500, param.verticalGap)
+        paramControls.onValueChanged {
+          param.verticalGap = _
+        }
+        this << paramControls.slider
+        this << paramControls.label
+      }
+
+      this << new ParamPanel("Vertical Strength", BoxLayout.X_AXIS) {
+        val param = config.tree
+        val paramControls = new LogParamControls(0.01, 10, param.verticalStrength)
+        paramControls.onValueChanged {
+          param.verticalStrength = _
+        }
+        this << paramControls.slider
+        this << paramControls.label
+      }
+
+      this << new JButton("Arrange Children by Link Order") with JButtonExt {
+        button =>
+        onActionPerformed { _ =>
+          val graph = LMNtal.source.current
+          if (graph != null) {
+            TreeLayout.arrangeChildren(graph)
+          }
+        }
+      }
+
+    }
+
+    this << new JPanel with JPanelExt {
+      layout_ = new BoxLayout(this, BoxLayout.Y_AXIS)
       border_ = new TitledBorder("Options")
 
       this << new JCheckBox("Show proxy") with JCheckBoxExt {
@@ -141,6 +177,55 @@ class ControlPanel(config: Config) extends JPanel with JPanelExt {
         checkBox =>
         onActionPerformed { _ => config.isAutoFocusEnabled = checkBox.isSelected }
       }
+      
+      var autoLayoutButton: JToggleButton = null
+      var treeLayoutButton: JToggleButton = null
+      
+      autoLayoutButton = new JToggleButton(
+        if (LMNtal.config.isAutoLayoutEnabled) "Auto Layout: ON" else "Auto Layout: OFF", 
+        LMNtal.config.isAutoLayoutEnabled
+      ) with JToggleButtonExt {
+        toggleButton =>
+        onActionPerformed { _ =>
+          val isEnabled = toggleButton.isSelected
+          config.isAutoLayoutEnabled = isEnabled
+          if (isEnabled) {
+            toggleButton.setText("Auto Layout: ON")
+            // オートレイアウトを有効にしたときはツリーレイアウトを無効化
+            config.isTreeLayoutEnabled = false
+            if (treeLayoutButton != null) {
+              treeLayoutButton.setSelected(false)
+              treeLayoutButton.setText("Tree Layout: OFF")
+            }
+          } else {
+            toggleButton.setText("Auto Layout: OFF")
+          }
+        }
+      }
+      this << autoLayoutButton
+      
+      treeLayoutButton = new JToggleButton(
+        if (LMNtal.config.isTreeLayoutEnabled) "Tree Layout: ON" else "Tree Layout: OFF", 
+        LMNtal.config.isTreeLayoutEnabled
+      ) with JToggleButtonExt {
+        toggleButton =>
+        onActionPerformed { _ =>
+          val isEnabled = toggleButton.isSelected
+          config.isTreeLayoutEnabled = isEnabled
+          if (isEnabled) {
+            toggleButton.setText("Tree Layout: ON")
+            // ツリーレイアウトを有効にしたときはオートレイアウトを無効化
+            config.isAutoLayoutEnabled = false
+            if (autoLayoutButton != null) {
+              autoLayoutButton.setSelected(false)
+              autoLayoutButton.setText("Auto Layout: OFF")
+            }
+          } else {
+            toggleButton.setText("Tree Layout: OFF")
+          }
+        }
+      }
+      this << treeLayoutButton
       this << new JButton("HeatUp") with JButtonExt {
         button =>
         onActionPerformed { _ => Hot.Temperature = 250.0 }
@@ -151,6 +236,145 @@ class ControlPanel(config: Config) extends JPanel with JPanelExt {
         onActionPerformed { _ => Hot.Always = checkBox.isSelected }
       }
       //*/
+    }
+
+    this << new JPanel with JPanelExt {
+      layout_ = new BoxLayout(this, BoxLayout.Y_AXIS)
+      border_ = new TitledBorder("Atom Style")
+
+      import java.awt.{Color, Dimension}
+      import javax.swing.event.{ListSelectionListener, ListSelectionEvent}
+
+      val styleListModel = new DefaultListModel[String]
+      val styleList = new JList[String](styleListModel)
+      styleList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+      val listScroll = new JScrollPane(styleList)
+      listScroll.setPreferredSize(new Dimension(200, 120))
+
+      val nameField = new JTextField("")
+      val shapeCombo = new JComboBox[String](AtomShape.values.map(_.label).toArray)
+
+      val sizeLabel = new JLabel("Size: 24")
+      val sizeSlider = new JSlider(10, 80, 24) with JSliderExt
+      sizeSlider.onStateChanged { _ => sizeLabel.setText("Size: " + sizeSlider.getValue) }
+
+      var fillColor: Color = Color.WHITE
+      var strokeColor: Color = Color.BLACK
+
+      def colorHex(c: Color): String = f"#${c.getRed}%02X${c.getGreen}%02X${c.getBlue}%02X"
+
+      def updateColorButton(button: JButton, color: Color): Unit = {
+        button.setBackground(color)
+        button.setForeground(if (color.getRed + color.getGreen + color.getBlue > 400) Color.BLACK else Color.WHITE)
+        button.setOpaque(true)
+        button.setBorderPainted(false)
+        button.setText(colorHex(color))
+      }
+
+      def chooseColor(current: Color): Color = {
+        val selected = JColorChooser.showDialog(this, "Select Color", current)
+        if (selected != null) selected else current
+      }
+
+      val fillButton = new JButton("") with JButtonExt
+      updateColorButton(fillButton, fillColor)
+      fillButton.onActionPerformed { _ =>
+        fillColor = chooseColor(fillColor)
+        updateColorButton(fillButton, fillColor)
+      }
+
+      val strokeButton = new JButton("") with JButtonExt
+      updateColorButton(strokeButton, strokeColor)
+      strokeButton.onActionPerformed { _ =>
+        strokeColor = chooseColor(strokeColor)
+        updateColorButton(strokeButton, strokeColor)
+      }
+
+      def refreshList(): Unit = {
+        styleListModel.clear()
+        for ((name, style) <- AtomStyleRegistry.all) {
+          styleListModel.addElement(s"${name} : ${style.shape.label}, size=${style.size}, fill=${colorHex(style.fillColor)}, stroke=${colorHex(style.strokeColor)}")
+        }
+      }
+
+      def applyAndRepaint(): Unit = {
+        val graph = LMNtal.source.current
+        AtomStyleRegistry.applyToGraph(graph)
+        graphene.core.gui.MainFrame.instance.mainPanel.repaint()
+      }
+
+      styleList.addListSelectionListener(new ListSelectionListener {
+        override def valueChanged(e: ListSelectionEvent): Unit = {
+          if (!e.getValueIsAdjusting) {
+            val idx = styleList.getSelectedIndex
+            if (idx >= 0 && idx < AtomStyleRegistry.all.size) {
+              val (name, style) = AtomStyleRegistry.all(idx)
+              nameField.setText(name)
+              shapeCombo.setSelectedItem(style.shape.label)
+              sizeSlider.setValue(style.size)
+              fillColor = style.fillColor
+              strokeColor = style.strokeColor
+              updateColorButton(fillButton, fillColor)
+              updateColorButton(strokeButton, strokeColor)
+            }
+          }
+        }
+      })
+
+      val applyButton = new JButton("Apply / Update") with JButtonExt
+      applyButton.onActionPerformed { _ =>
+        val name = nameField.getText.trim
+        if (name.nonEmpty) {
+          val shape = AtomShape.fromLabel(shapeCombo.getSelectedItem.toString)
+          val size = sizeSlider.getValue
+          val corner = math.max(6, size / 3)
+          val style = AtomStyle(fillColor, strokeColor, strokeColor, shape, size, corner)
+          AtomStyleRegistry.upsert(name, style)
+          refreshList()
+          applyAndRepaint()
+        }
+      }
+
+      val removeButton = new JButton("Remove") with JButtonExt
+      removeButton.onActionPerformed { _ =>
+        val name = nameField.getText.trim
+        if (name.nonEmpty) {
+          AtomStyleRegistry.remove(name)
+          refreshList()
+          applyAndRepaint()
+        }
+      }
+
+      val clearButton = new JButton("Clear All") with JButtonExt
+      clearButton.onActionPerformed { _ =>
+        AtomStyleRegistry.clear()
+        refreshList()
+        applyAndRepaint()
+      }
+
+      this << new JLabel("Atom name")
+      this << nameField
+
+      this << new JLabel("Shape")
+      this << shapeCombo
+
+      this << sizeLabel
+      this << sizeSlider
+
+      this << new JLabel("Fill color")
+      this << fillButton
+
+      this << new JLabel("Stroke color")
+      this << strokeButton
+
+      this << applyButton
+      this << removeButton
+      this << clearButton
+
+      this << new JLabel("Rules")
+      this << listScroll
+
+      refreshList()
     }
 
     this << new JPanel with JPanelExt {

--- a/src/main/scala/graphene/plugin/lmntal/LMNtal.scala
+++ b/src/main/scala/graphene/plugin/lmntal/LMNtal.scala
@@ -40,6 +40,11 @@ class ForceParams {
 
 }
 
+class TreeLayoutParams {
+  var verticalGap = 80.0
+  var verticalStrength = 1.0
+}
+
 class Config {
   var lmntalHome = ""
   var slimPath = ""
@@ -48,7 +53,10 @@ class Config {
   var isProxyVisible = false
   var isDiffAnimationEnabled = false
   var isAutoFocusEnabled = false
+  var isAutoLayoutEnabled: Boolean = true
+  var isTreeLayoutEnabled: Boolean = false
   val forces = new ForceParams
+  val tree = new TreeLayoutParams
 }
 
 object LMNtal extends Plugin {
@@ -73,6 +81,8 @@ object LMNtal extends Plugin {
 
     config.baseDirectory     = properties.getProperty("base_directory", "~/")
     config.additionalOptions = properties.getProperty("additional_options", "")
+    config.isAutoLayoutEnabled = properties.getProperty("auto_layout_enabled", "true").toBoolean
+    config.isTreeLayoutEnabled = properties.getProperty("tree_layout_enabled", "false").toBoolean
   }
 
   def exportProperties: java.util.Properties = {
@@ -81,6 +91,8 @@ object LMNtal extends Plugin {
     properties.setProperty("slim_path", config.slimPath)
     properties.setProperty("base_directory", config.baseDirectory)
     properties.setProperty("additional_options", config.additionalOptions)
+    properties.setProperty("auto_layout_enabled", config.isAutoLayoutEnabled.toString)
+    properties.setProperty("tree_layout_enabled", config.isTreeLayoutEnabled.toString)
     properties
   }
 

--- a/src/main/scala/graphene/plugin/lmntal/Mover.scala
+++ b/src/main/scala/graphene/plugin/lmntal/Mover.scala
@@ -21,22 +21,36 @@ object DefaultMover extends LMNtal.Mover {
     moveAll(graph, elapsedSec, LMNtal.config.forces)
 
   def moveAll(graph: Graph, elapsedSec: Double, params: ForceParams): Unit = {
-    if (graph == null) return
+    val useAuto = LMNtal.config.isAutoLayoutEnabled
+    val useTree = LMNtal.config.isTreeLayoutEnabled
+    if (graph == null || (!useAuto && !useTree)) return
+
+    val treeParams = TreeLayout.Params(
+      LMNtal.config.tree.verticalGap,
+      LMNtal.config.tree.verticalStrength
+    )
+    val treeCtx = if (useTree) TreeLayout.buildContext(graph) else TreeLayout.EmptyContext
+
     transaction(graph) {
-      move(graph.rootNode, elapsedSec, Point.zero, params)
+      moveAll(graph.rootNode, elapsedSec, Point.zero, params, useAuto, useTree, treeCtx, treeParams)
     }
     resize(graph.rootNode)
   }
 
-  private def move(node: Node, elapsedSec: Double, parentForce: Point, params: ForceParams): Unit = {
+  private def moveAll(node: Node, elapsedSec: Double, parentForce: Point, params: ForceParams, useAuto: Boolean, useTree: Boolean, treeCtx: TreeLayout.Context, treeParams: TreeLayout.Params): Unit = {
     if (node.view.fixed || node.view.selected) return
 
-    val force = forceFor(node, params) + parentForce
+    val baseForce = if (useAuto) forceFor(node, params) else Point.zero
+    val treeForce = if (useTree) TreeLayout.forceFor(node, treeCtx, treeParams) else Point.zero
+    val rawForce = baseForce + treeForce + parentForce
+    val force =
+      if (useTree && treeCtx.noParent.contains(node)) Point(rawForce.x, 0.0)
+      else rawForce
 
     node.view.affect(force, elapsedSec)
 
     val childNodes = node.childNodes
-    for (n <- childNodes) move(n, elapsedSec, force / node.childNodes.size, params)
+    for (n <- childNodes) moveAll(n, elapsedSec, force / node.childNodes.size, params, useAuto, useTree, treeCtx, treeParams)
   }
 
   private def resize(node: Node): Unit = {
@@ -113,23 +127,37 @@ object FastMover extends LMNtal.Mover {
     moveAll(graph, elapsedSec, LMNtal.config.forces)
 
   def moveAll(graph: Graph, elapsedSec: Double, params: ForceParams): Unit = {
-    if (graph == null) return
+    val useAuto = LMNtal.config.isAutoLayoutEnabled
+    val useTree = LMNtal.config.isTreeLayoutEnabled
+    if (graph == null || (!useAuto && !useTree)) return
+
+    val treeParams = TreeLayout.Params(
+      LMNtal.config.tree.verticalGap,
+      LMNtal.config.tree.verticalStrength
+    )
+    val treeCtx = if (useTree) TreeLayout.buildContext(graph) else TreeLayout.EmptyContext
+
     transaction(graph) {
-      move(graph.rootNode, elapsedSec, Point.zero, params)
+      move(graph.rootNode, elapsedSec, Point.zero, params, useAuto, useTree, treeCtx, treeParams)
     }
     resize(graph.rootNode)
   }
 
   //NOTE アトムを動かします。固定されている、選択されているものについては動かしません。
-  private def move(node: Node, elapsedSec: Double, parentForce: Point, params: ForceParams): Unit = {
+  private def move(node: Node, elapsedSec: Double, parentForce: Point, params: ForceParams, useAuto: Boolean, useTree: Boolean, treeCtx: TreeLayout.Context, treeParams: TreeLayout.Params): Unit = {
     if (node.view.fixed || node.view.selected) return
 
-    val force = forceFor(node, params) + parentForce
+    val baseForce = if (useAuto) forceFor(node, params) else Point.zero
+    val treeForce = if (useTree) TreeLayout.forceFor(node, treeCtx, treeParams, params) else Point.zero
+    val rawForce = baseForce + treeForce + parentForce
+    val force =
+      if (useTree && treeCtx.noParent.contains(node)) Point(rawForce.x, 0.0)
+      else rawForce
 
     node.view.affect(force, elapsedSec)
 
     val childNodes = node.childNodes
-    for (n <- childNodes) move(n, elapsedSec, force / node.childNodes.size, params)
+    for (n <- childNodes) move(n, elapsedSec, force / node.childNodes.size, params, useAuto, useTree, treeCtx, treeParams)
   }
 
   private def resize(node: Node): Unit = {

--- a/src/main/scala/graphene/plugin/lmntal/Observer.scala
+++ b/src/main/scala/graphene/plugin/lmntal/Observer.scala
@@ -46,24 +46,39 @@ class Observer extends LMNtal.Observer {
   import java.awt.event.{KeyEvent}
   import java.awt.{Point => JPoint}
 
-  import scala.collection.mutable
+  import scala.collection.mutable.{Set => MutableSet}
 
   private lazy val gctx = graphene.core.gui.MainFrame.instance.mainPanel.graphicsContext
 
-  private val selectedNodes = mutable.Set.empty[Node]
+  private val selectedNodes = MutableSet.empty[Node]
   private var prevPoint: JPoint = null
   private var canMoveNode = false
   private var isMultiSelectionEnabled = false
+  private var lastRightClickedPoint: JPoint = null
 
   val popupMenu = new javax.swing.JPopupMenu {
     import java.awt.event.{ActionListener,ActionEvent}
     import javax.swing.{JMenuItem}
 
-    val item = new JMenuItem("Propagation coloring")
-    item.addActionListener(new ActionListener {
+    val coloringItem = new JMenuItem("Propagation coloring")
+    coloringItem.addActionListener(new ActionListener {
       def actionPerformed(e: ActionEvent) = Observer.doSmoothColoring(selectedNodes.toSet)
     })
-    add(item)
+    add(coloringItem)
+
+    val treeLayoutItem = new JMenuItem("Tree layout")
+    treeLayoutItem.addActionListener(new ActionListener {
+      def actionPerformed(e: ActionEvent) = {
+        val graph = LMNtal.source.current
+        val rootNodeOpt = Observer.nodeOptAt(gctx.worldPointFrom(lastRightClickedPoint))
+        
+        for (graph <- Option(graph); rootNode <- rootNodeOpt if selectedNodes.contains(rootNode)) {
+          TreeLayoutManager.layout(graph, rootNode)
+          graphene.core.gui.MainFrame.instance.mainPanel.repaint()
+        }
+      }
+    })
+    add(treeLayoutItem)
   }
 
   private def resetSelection() = {
@@ -72,7 +87,10 @@ class Observer extends LMNtal.Observer {
   }
 
   def listener: Reactions.Reaction = {
-    case MousePressed(source, p, _, _, true) => popupMenu.show(source, p.x, p.y)
+    case MousePressed(source, p, _, _, true) => {
+      lastRightClickedPoint = p
+      popupMenu.show(source, p.x, p.y)
+    }
     case MousePressed(_, p, _, _, _)  => {
       Observer.nodeOptAt(gctx.worldPointFrom(p)) match {
         case Some(n) => {

--- a/src/main/scala/graphene/plugin/lmntal/Renderer.scala
+++ b/src/main/scala/graphene/plugin/lmntal/Renderer.scala
@@ -85,20 +85,38 @@ class DefaultRenderer extends LMNtal.Renderer {
 
     node.attr match {
       case Atom => {
+        val styleOpt = AtomStyleRegistry.styleFor(node)
+        val shape = styleOpt.map(_.shape).getOrElse(AtomShape.Circle)
+        val fillColor = styleOpt.map(_.fillColor).getOrElse(Color.WHITE)
+        val strokeColor = styleOpt.map(_.strokeColor).getOrElse(node.view.color)
+        val textColor = styleOpt.map(_.textColor).getOrElse(node.view.color)
+        val cornerRadius = styleOpt.map(_.cornerRadius).getOrElse(8)
+
         g.setFont(font)
-        g.setColor(node.view.color)
+        g.setColor(textColor)
         g.drawString(node.name, rect.point)
 
-        g.setColor(if (view.selected) Palette.asbestos else Color.WHITE)
-        g.fillOval(rect)
+        g.setColor(if (view.selected) Palette.asbestos else fillColor)
+        shape match {
+          case AtomShape.Circle =>
+            g.fillOval(rect)
+          case AtomShape.RoundedRect =>
+            g.fillRoundRect(rect, Dim(cornerRadius, cornerRadius))
+        }
 
         g.setStroke(atomStroke)
-        g.setColor(node.view.color)
-        g.drawOval(rect)
+        g.setColor(strokeColor)
+        shape match {
+          case AtomShape.Circle =>
+            g.drawOval(rect)
+          case AtomShape.RoundedRect =>
+            g.drawRoundRect(rect, Dim(cornerRadius, cornerRadius))
+        }
       }
       case HLAtom => {
         g.setFont(font)
-        g.setColor(node.view.color)
+        // g.setColor(node.view.color)
+        g.setColor(Palette.hlLink)
         g.drawString(node.name, rect.point)
         g.fillOval(rect)
       }
@@ -123,13 +141,17 @@ class DefaultRenderer extends LMNtal.Renderer {
   }
 
   private def renderEdge(g: Graphics2D, edge: Edge): Unit = {
-    g.setColor(Palette.concrete)
+    // g.setColor(Palette.concrete)
+    val isHL = edge.source.attr == HLAtom || edge.target.attr == HLAtom
+    g.setColor(if (isHL) Palette.hlLink else Palette.concrete)
     g.setStroke(linkStroke)
     g.drawLine(edge.source.view.rect.center, edge.target.view.rect.center)
   }
 
   private def renderSelfEdges(g: Graphics2D, edges: Seq[Edge]): Unit = {
-    g.setColor(Palette.concrete)
+    // g.setColor(Palette.concrete)
+    val isHL = edges.head.source.attr == HLAtom
+    g.setColor(if (isHL) Palette.hlLink else Palette.concrete)
     g.setStroke(linkStroke)
     val size = edges.size
     val edge = edges.head
@@ -144,7 +166,9 @@ class DefaultRenderer extends LMNtal.Renderer {
   }
 
   private def renderMultipleEdges(g: Graphics2D, edges: Seq[Edge]): Unit = {
-    g.setColor(Palette.concrete)
+    // g.setColor(Palette.concrete)
+    val isHL = edges.head.source.attr == HLAtom || edges.head.target.attr == HLAtom
+    g.setColor(if (isHL) Palette.hlLink else Palette.concrete)
     g.setStroke(linkStroke)
     val edge = edges.head
     val size = edges.size

--- a/src/main/scala/graphene/plugin/lmntal/Source.scala
+++ b/src/main/scala/graphene/plugin/lmntal/Source.scala
@@ -28,6 +28,7 @@ class LMNtalSource extends LMNtal.Source {
         case _ => Palette.lightGray
       }
     }
+    AtomStyleRegistry.applyToGraph(graph)
     graph
   }
 
@@ -165,7 +166,9 @@ private object LMN {
     val graph = new Graph {
       viewBuilder = (n: Node) => {
         val rect = n.attr match {
-          case Atom => Rect(Point.randomPointIn(gctx.wRect), Dim(24, 24))
+          case Atom =>
+            val size = AtomStyleRegistry.get(n.name).map(_.size).getOrElse(AtomStyleRegistry.DefaultAtomSize)
+            Rect(Point.randomPointIn(gctx.wRect), Dim(size, size))
           case HLAtom => Rect(Point.randomPointIn(gctx.wRect), Dim(12, 12))
           case _ => Rect(Point(0, 0), Dim(10, 10))
         }
@@ -181,7 +184,13 @@ private object LMN {
 
     for (linkSet <- links) {
       val ls = linkSet.toSeq
-      graph.createEdge(ls(0)._1, ls(1)._1)
+      val (id1, pos1) = ls(0)
+      val (id2, pos2) = ls(1)
+      val n1 = graph.nodeOf(id1)
+      val n2 = graph.nodeOf(id2)
+      graph.createEdge(n1, n2)
+      graph.recordPortOrder(n1, pos1, n2)
+      graph.recordPortOrder(n2, pos2, n1)
     }
 
     graph

--- a/src/main/scala/graphene/plugin/lmntal/TreeLayout.scala
+++ b/src/main/scala/graphene/plugin/lmntal/TreeLayout.scala
@@ -1,0 +1,272 @@
+package graphene.plugin.lmntal
+
+import graphene.model._
+import graphene.util._
+import scala.collection.mutable
+
+object TreeLayout {
+
+  case class Params(verticalGap: Double, verticalStrength: Double)
+
+  case class Context(
+    parent: Map[Node, Option[Node]],
+    orderedChildren: Map[Node, Seq[Node]],
+    sameLevelNeighbors: Map[Node, Seq[Node]],
+    noParent: Set[Node]
+  )
+
+  val EmptyContext = Context(Map.empty, Map.empty, Map.empty, Set.empty)
+
+  def buildContext(graph: Graph): Context = {
+    val parent = mutable.Map.empty[Node, Option[Node]]
+    val sameLevel = mutable.Map.empty[Node, mutable.ArrayBuffer[Node]]
+    val alive = graph.allNodes.toSet
+
+    def addSameLevel(a: Node, b: Node): Unit = {
+      sameLevel.getOrElseUpdate(a, mutable.ArrayBuffer.empty) += b
+      sameLevel.getOrElseUpdate(b, mutable.ArrayBuffer.empty) += a
+    }
+
+    for (node <- graph.allNodes) {
+      if (node.isRoot) {
+        parent(node) = None
+      } else node.attr match {
+        case Mem => parent(node) = None
+        case _ =>
+          val ordered = graph.orderedNeighbors(node).filter(alive.contains)
+          val fallback = if (ordered.nonEmpty) ordered else node.neighborNodes.filter(alive.contains)
+          parent(node) = fallback.lastOption
+      }
+    }
+
+    val handled = mutable.Set.empty[(Node, Node)]
+    for ((node, pOpt) <- parent) {
+      pOpt.foreach { p =>
+        val pair = (node, p)
+        if (!handled.contains(pair) && parent.getOrElse(p, None).contains(node)) {
+          (node.attr, p.attr) match {
+            case (HLAtom, _) =>
+              parent(node) = None
+              parent(p) = Some(node)
+            case (_, HLAtom) =>
+              parent(p) = None
+              parent(node) = Some(p)
+            case _ =>
+              parent(node) = None
+              parent(p) = None
+              addSameLevel(node, p)
+          }
+          handled += pair
+          handled += ((p, node))
+        }
+      }
+    }
+
+    val hlGroups = graph.allNodes.filter(_.attr == HLAtom).groupBy(_.id)
+    for ((_, groupNodes) <- hlGroups) {
+      val groupSet = groupNodes.toSet
+      // グループ全体の親候補を一度だけ探す
+      val connectedToHL = groupNodes.flatMap(_.neighborNodes).distinct
+      
+      // 親がグループに到達するノード（=グループの子孫）を除外して循環を防ぐ
+      def isDescendantOfGroup(n: Node): Boolean = {
+        var cur: Node = n
+        val seen = mutable.Set.empty[Node]
+        while (cur != null && !seen.contains(cur)) {
+          if (groupSet.contains(cur)) return true
+          seen += cur
+          cur = parent.getOrElse(cur, None).orNull
+        }
+        false
+      }
+
+      // その中から、グループに到達しないアトムのみを抽出
+      val candidatesNotPointingToGroup = connectedToHL.filter { p =>
+        !groupSet.contains(p) && !isDescendantOfGroup(p)
+      }
+      
+      // グループ内のすべてのHLアトムに同じ親を設定
+      if (candidatesNotPointingToGroup.isEmpty) {
+        // 親候補が見つからない場合、物理レイアウトを使用
+        for (h <- groupNodes) {
+          parent(h) = None
+        }
+      } else {
+        // 候補の中でy座標が最も大きい（画面下方）ものを親にする
+        val chosen = candidatesNotPointingToGroup.maxBy(_.view.rect.center.y)
+        for (h <- groupNodes) {
+          parent(h) = Some(chosen)
+        }
+      }
+    }
+
+    // 親指定の循環を検出して破壊（1サイクルにつき1ノードの親を外す）
+    def breakParentCycles(): Unit = {
+      val visiting = mutable.Set.empty[Node]
+      val visited = mutable.Set.empty[Node]
+
+      def follow(start: Node): Unit = {
+        if (visited.contains(start)) return
+        var current = start
+        val path = mutable.ArrayBuffer.empty[Node]
+        while (current != null && !visited.contains(current)) {
+          if (visiting.contains(current)) {
+            val idx = path.indexOf(current)
+            if (idx >= 0) {
+              val cycle = path.drop(idx)
+              // 画面上方のノードを親なしにして循環を解消（下方向ドリフトを防ぐ）
+              val cut = cycle.minBy(_.view.rect.center.y)
+              parent(cut) = None
+            }
+            return
+          }
+          visiting += current
+          path += current
+          current = parent.getOrElse(current, None).orNull
+        }
+        for (n <- path) {
+          visiting -= n
+          visited += n
+        }
+      }
+
+      for (n <- parent.keys) follow(n)
+    }
+
+    breakParentCycles()
+
+    val orderedChildren = mutable.Map.empty[Node, Seq[Node]]
+    for ((node, _) <- parent) {
+      val children = parent.collect { case (child, Some(p)) if p eq node => child }.toSeq
+      if (children.nonEmpty) {
+        val ordered = graph.orderedNeighbors(node).filter(children.contains)
+        val sorted =
+          if (ordered.nonEmpty) ordered ++ children.filterNot(ordered.contains)
+          else children
+        orderedChildren(node) = sorted
+      }
+    }
+
+    // Track nodes without assigned parents (for fallback to physics layout)
+    val noParent = parent.collect { case (node, None) if !node.isRoot => node }.toSet
+
+    Context(parent.toMap, orderedChildren.toMap, sameLevel.map { case (k, v) => k -> v.toSeq }.toMap, noParent)
+  }
+
+  def forceFor(node: Node, ctx: Context, params: Params): Point = {
+    if ((ctx eq EmptyContext) || node.isRoot) return Point.zero
+
+    val self = node.view.rect.center
+
+    val parentForce = ctx.parent.getOrElse(node, None).map { parent =>
+      val targetY = parent.view.rect.center.y + params.verticalGap
+      val dy = targetY - self.y
+      Point(0.0, dy * params.verticalStrength)
+    }.getOrElse(Point.zero)
+
+    parentForce
+  }
+
+  def forceFor(node: Node, ctx: Context, params: Params, forceParams: graphene.plugin.lmntal.ForceParams): Point = {
+    if ((ctx eq EmptyContext) || node.isRoot) return Point.zero
+
+    val self = node.view.rect.center
+    val physics = DefaultMover.forceFor(node, forceParams)
+
+    val parentOpt = ctx.parent.getOrElse(node, None)
+    val peersOpt = ctx.sameLevelNeighbors.get(node)
+
+    // 親候補も同レベルの仲間もいない場合は、y方向を固定し、x方向のみ物理レイアウト
+    if (parentOpt.isEmpty && peersOpt.forall(_.isEmpty)) {
+      return Point(physics.x, 0.0)
+    }
+
+    // x方向の力：従来の力学モデルのx成分を使用
+    val xForce = physics.x
+
+    val parentYForce = parentOpt.map { parent =>
+      val targetY = parent.view.rect.center.y + params.verticalGap
+      val dy = targetY - self.y
+      // デッドゾーン：目標位置から一定距離以内なら力を加えない
+      val deadZone = params.verticalGap * 0.1
+      if (math.abs(dy) < deadZone) {
+        0.0
+      } else if (dy > 0) {
+        // 親より下にいる場合：上方向に引っ張る
+        (dy - deadZone) * params.verticalStrength
+      } else {
+        // 親より上にいる場合：下方向に引っ張る
+        (dy + deadZone) * params.verticalStrength
+      }
+    }.getOrElse(0.0)
+
+    Point(xForce, parentYForce)
+  }
+
+  // 強制配置：子ノードを親ノードの真下にリンク順で並べる
+  def arrangeChildren(graph: Graph): Unit = {
+    val ctx = buildContext(graph)
+    val nodeSpacing = 10.0     // ノード間の最小スペース（ノードサイズ1つ分）
+    val verticalGap = 80.0     // 親子間の垂直距離
+    
+    // 各ノードの部分木の幅を計算
+    def calculateSubtreeWidth(node: Node): Double = {
+      val children = ctx.orderedChildren.getOrElse(node, Seq.empty)
+      if (children.isEmpty) {
+        nodeSpacing
+      } else if (children.size == 1) {
+        // 子が1つだけの場合は、その子の幅をそのまま使用
+        calculateSubtreeWidth(children.head)
+      } else {
+        // 複数の子がある場合：各子の幅の合計
+        children.map(calculateSubtreeWidth).sum
+      }
+    }
+    
+    // ノードとその子孫を配置
+    def arrange(node: Node, centerX: Double, topY: Double): Unit = {
+      val children = ctx.orderedChildren.getOrElse(node, Seq.empty)
+      
+      // ノード自身を中央に配置
+      val currentCenter = node.view.rect.center
+      val dx = centerX - currentCenter.x
+      val dy = topY - currentCenter.y
+      node.view.rect = node.view.rect.movedBy(Point(dx, dy))
+      
+      if (children.nonEmpty) {
+        if (children.size == 1) {
+          // 子が1つだけの場合：親の真下に配置
+          val child = children.head
+          val childY = topY + verticalGap
+          arrange(child, centerX, childY)
+        } else {
+          // 複数の子がある場合：左から順に配置
+          val childWidths = children.map(calculateSubtreeWidth)
+          val totalWidth = childWidths.sum
+          
+          // 子ノードたちを左から順に配置
+          var currentX = centerX - totalWidth / 2.0
+          for ((child, width) <- children.zip(childWidths)) {
+            val childCenterX = currentX + width / 2.0
+            val childY = topY + verticalGap
+            
+            // 再帰的に子ノードとその子孫を配置
+            arrange(child, childCenterX, childY)
+            
+            currentX += width
+          }
+        }
+      }
+    }
+    
+    // ルートノードから開始
+    if (!graph.rootNode.isRoot) {
+      arrange(graph.rootNode, 0.0, 0.0)
+    } else {
+      for (child <- graph.rootNode.childNodes) {
+        arrange(child, child.view.rect.center.x, child.view.rect.center.y)
+      }
+    }
+  }
+
+}

--- a/src/main/scala/graphene/plugin/lmntal/TreeLayoutManager.scala
+++ b/src/main/scala/graphene/plugin/lmntal/TreeLayoutManager.scala
@@ -1,0 +1,75 @@
+package graphene.plugin.lmntal
+
+import graphene.model.{Graph, Node}
+import graphene.util.{Line, Point, Rect}
+
+import scala.collection.mutable
+
+object TreeLayoutManager {
+
+  // 各階層の垂直・水平方向の間隔
+  private val DEFAULT_VERTICAL_SPACING = 120.0
+  private val DEFAULT_HORIZONTAL_SPACING = 100.0
+
+  /**
+   * 指定されたノードを基点として木構造レイアウトを実行します。
+   * @param graph 対象のグラフ
+   * @param rootNode レイアウトの基点となるノード
+   */
+  def layout(graph: Graph, rootNode: Node): Unit = {
+    // レイアウト前の平均エッジ長から、レイアウト間隔を決定する
+    val (verticalSpacing, horizontalSpacing) = if (graph.allEdges.nonEmpty) {
+      val totalLength = graph.allEdges.map { edge =>
+        Line.from(edge.source.view.rect.center).to(edge.target.view.rect.center).length
+      }.sum
+      val average = totalLength / graph.allEdges.length
+      (average, average)
+    } else {
+      // エッジがない場合はデフォルト値を使用
+      (DEFAULT_VERTICAL_SPACING, DEFAULT_HORIZONTAL_SPACING)
+    }
+
+    // 1. 幅優先探索(BFS)で各ノードの深さと階層ごとのノードリストを作成
+    val depths = mutable.Map[Node, Int]()
+    val nodesByDepth = mutable.Map[Int, mutable.ArrayBuffer[Node]]()
+    val queue = mutable.Queue[(Node, Int)]()
+
+    // 基点ノードを深さ0として初期化
+    queue.enqueue((rootNode, 0))
+    depths(rootNode) = 0
+
+    while (queue.nonEmpty) {
+      val (current, depth) = queue.dequeue()
+      nodesByDepth.getOrElseUpdate(depth, mutable.ArrayBuffer()) += current
+
+      // 隣接ノードを探索
+      current.neighborNodes.foreach { neighbor =>
+        if (!depths.contains(neighbor)) {
+          depths(neighbor) = depth + 1
+          queue.enqueue((neighbor, depth + 1))
+        }
+      }
+    }
+
+    // 2. 各ノードの新しい座標を計算して位置を更新
+    val rootInitialPos = rootNode.view.rect.point
+
+    nodesByDepth.foreach { case (depth, nodes) =>
+      val levelWidth = (nodes.length - 1) * horizontalSpacing
+      val startX = rootInitialPos.x - levelWidth / 2
+      val y = rootInitialPos.y + depth * verticalSpacing
+
+      nodes.zipWithIndex.foreach { case (node, index) =>
+        // fixed(固定)されているノードは移動しない
+        if (!node.view.fixed) {
+          val x = startX + index * horizontalSpacing
+          val currentRect = node.view.rect
+          // ノードのサイズは維持し、位置のみを更新
+          node.view.rect = Rect(Point(x, y), currentRect.dim)
+        }
+      }
+    }
+
+    // TODO: 画面の再描画を要求する処理を呼び出す (例: panel.repaint())
+  }
+}

--- a/src/main/scala/graphene/util/Color.scala
+++ b/src/main/scala/graphene/util/Color.scala
@@ -24,4 +24,5 @@ object Palette {
   val lightGray = Color.fromHSB(0.8f, 0.05f, 0.75f)
   val asbestos = new JColor(127, 140, 141)
   val concrete = new JColor(149, 165, 166)
+  val hlLink = new JColor(0x6C, 0x8E, 0xBF)
 }


### PR DESCRIPTION
- 自動整形機能のON/OFFを追加
- 従来の力学的レイアウトとは独立のtree-layoutモードを追加
     - 従来のレイアウトON / ツリーレイアウトON / 両方OFF（アトムが勝手に動かない）の3パターンが選べる状態
- 指定したアトム名のアトムの色/形を変更できる機能を追加
- 上記に合わせてコントロールパネルのレイアウトを修正
- （力学的ツリー整形とは完全に別で、手動で指定したルートノードを基準に深さを計算して配置する強制配置機能も実装しました。アトムの右クリックで出るメニュー内のボタンで実行できます）

### tree-layoutモード
- 木構造が`P=node(C,C,C)`の形式で記述されることが多いことを前提として、最終リンクに接続されたアトムを親として、親アトムの下に自信を配置する